### PR TITLE
VizBlocks: Draw a heat map

### DIFF
--- a/src/extensions/scratch3_vizblocks/index.js
+++ b/src/extensions/scratch3_vizblocks/index.js
@@ -67,16 +67,16 @@ class Scratch3VizBlocks {
          */
         this._penSkinId = -1;
 
-        // Initiate canvas and center of coordinate system for the line chart / dot plot
-        this._xCenter = -160;
-        this._yCenter = -100;
-        this._width = 360;
-        this._height = 200;
-
         // Shared variables
         this._xMarkers = 10;
         this._yMarkers = 5;
         this._interval = 36;
+        this._xCenter = -160;
+        this._yCenter = -100;
+
+        // Initiate canvas and center of coordinate system for the line chart / dot plot
+        this._chartWidth = 360;
+        this._chartHeight = 200;
 
         // Variables for line graph
         this._xArray = [];
@@ -106,6 +106,15 @@ class Scratch3VizBlocks {
         this._categorySizesArr = [];
         this._pieChartSize = 0;
         this._colors = [];
+
+        // Variables for grid
+        this._gridWidth = 360;
+        this._gridHeight = 180;
+        this._gridValues = [];
+        this._safeColor = '#6ef649';
+        this._mildColor = '#f6e749';
+        this._severeColor = '#f6b649';
+        this._dangerColor = '#f64949';
 
         // Costumes array
         this._costumes = [];
@@ -251,6 +260,31 @@ class Scratch3VizBlocks {
                 this.runtime.requestRedraw();
             }
         }
+    }
+
+    /**
+     * Sets the pen to a particular RGB color.
+     * The transparency is reset to 0.
+     * @param {int} color - the color to set, expressed as a 24-bit RGB value (0xRRGGBB).
+     * @param {RenderedTarget} target - target object that has been updated.
+     */
+    setPenColorToColor (color, target) {
+        const penState = this._getPenState(target);
+        const rgb = Cast.toRgbColorObject(color);
+        const hsv = Color.rgbToHsv(rgb);
+        penState.color = (hsv.h / 360) * 100;
+        penState.saturation = hsv.s * 100;
+        penState.brightness = hsv.v * 100;
+        if (rgb.hasOwnProperty('a')) {
+            penState.transparency = 100 * (1 - (rgb.a / 255.0));
+        } else {
+            penState.transparency = 0;
+        }
+
+        // Set the legacy "shade" value the same way scratch 2 did.
+        penState._shade = penState.brightness / 2;
+
+        this._updatePenColor(penState);
     }
 
     /**
@@ -455,6 +489,31 @@ class Scratch3VizBlocks {
                     }
                 },
                 {
+                    opcode: 'readGridXYValues',
+                    blockType: BlockType.COMMAND,
+                    text: formatMessage({
+                        id: 'vizblocks.readGridXY',
+                        default: 'read grid x:[GRID_X_VALUES] y:[GRID_Y_VALUES] count:[count]',
+                        description: 'read from (X, Y)'
+                    }),
+                    arguments: {
+                        GRID_X_VALUES: {
+                            type: ArgumentType.STRING,
+                            menu: 'GRID_X_VALUES',
+                            defaultValue: '1'
+                        },
+                        GRID_Y_VALUES: {
+                            type: ArgumentType.STRING,
+                            menu: 'GRID_Y_VALUES',
+                            defaultValue: '1'
+                        },
+                        count: {
+                            type: ArgumentType.NUMBER,
+                            defaultValue: 1
+                        }
+                    }
+                },
+                {
                     opcode: 'drawXAxis',
                     blockType: BlockType.COMMAND,
                     text: formatMessage({
@@ -538,6 +597,22 @@ class Scratch3VizBlocks {
                         default: 'draw pie',
                         description: 'draw pie'
                     })
+                },
+                {
+                    opcode: 'drawGrid',
+                    blockType: BlockType.COMMAND,
+                    text: formatMessage({
+                        id: 'vizblocks.drawGrid',
+                        default: 'draw grid for [PICTURE]',
+                        description: 'draw grid'
+                    }),
+                    arguments: {
+                        PICTURE: {
+                            type: ArgumentType.STRING,
+                            menu: 'PICTURE',
+                            defaultValue: this._customSprites[0]
+                        }
+                    }
                 }
             ],
             menus: {
@@ -556,6 +631,14 @@ class Scratch3VizBlocks {
                 PICTURE: {
                     acceptReporters: true,
                     items: this._customSprites
+                },
+                GRID_X_VALUES: {
+                    acceptReporters: true,
+                    items: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
+                },
+                GRID_Y_VALUES: {
+                    acceptReporters: true,
+                    items: ['1', '2', '3', '4', '5']
                 }
             }
         };
@@ -571,11 +654,12 @@ class Scratch3VizBlocks {
     clear (args, util) {
         const penSkinId = this._getPenLayerID();
         const target = util.target;
-        target.setVisible(false);
         if (penSkinId >= 0) {
             this.runtime.renderer.penClear(penSkinId);
             this.runtime.requestRedraw();
         }
+        // Default blue
+        this.setPenColorToColor('#0000ff', target);
 
         // Clear for line chart or scatter plot
         if (!this._posEmpty) {
@@ -586,7 +670,7 @@ class Scratch3VizBlocks {
             this._posEmpty = true;
         }
 
-        // Clear for dot plot or scatter plot
+        // Clear for dot plot
         this._valCountMap = new Map();
         this._dotPos = [];
         this.setPenSizeTo(1, target);
@@ -603,6 +687,10 @@ class Scratch3VizBlocks {
         this._xPieStart = -250;
         this._yPieStart = 150;
 
+        // Clear for grid
+        this._gridValues = [];
+
+        // Delete costumes that are loaded
         target.sprite.costumes_.forEach(costume => {
             if (costume.name !== 'costume1' && costume.name !== 'costume2' && !newCostumeNames.includes(costume.name)) {
                 target.deleteCostume(target.getCostumeIndexByName(costume.name));
@@ -663,6 +751,22 @@ class Scratch3VizBlocks {
     }
 
     /**
+     * Read data from grid input as (x, y, count)
+     * @param {object} args - the block arguments.
+     */
+    readGridXYValues (args) {
+        const x = Cast.toNumber(args.GRID_X_VALUES);
+        const y = Cast.toNumber(args.GRID_Y_VALUES);
+        const count = Cast.toNumber(args.count);
+
+        this._gridValues.push({
+            x,
+            y,
+            count
+        });
+    }
+
+    /**
      * Draw x-axis for line chart or dot plot.
      * @param {object} args - the block arguments.
      * @param {object} util - utility object provided by the runtime.
@@ -678,7 +782,7 @@ class Scratch3VizBlocks {
         const penSkinId = this._getPenLayerID();
         if (penSkinId >= 0) {
             const penState = this._getPenState(target);
-            target.x = this._xCenter + this._width;
+            target.x = this._xCenter + this._chartWidth;
             target.y = this._yCenter;
             // draw x-axis line
             this.runtime.renderer.penLine(penSkinId, penState.penAttributes, this._xCenter, this._yCenter, target.x, target.y);
@@ -706,7 +810,7 @@ class Scratch3VizBlocks {
         if (penSkinId >= 0) {
             const penState = this._getPenState(target);
             target.x = this._xCenter;
-            target.y = this._yCenter + this._height;
+            target.y = this._yCenter + this._chartHeight;
             // draw y-axis line
             this.runtime.renderer.penLine(penSkinId, penState.penAttributes, this._xCenter, this._yCenter, target.x, target.y);
 
@@ -880,7 +984,71 @@ class Scratch3VizBlocks {
         }
     }
 
+    /**
+     * Draw grid for the heatmap.
+     * @param {object} args - the block arguments.
+     * @param {object} util - utility object provided by the runtime.
+     */
+    drawGrid (args, util) {
+        const target = util.target;
+        const penSkinId = this._getPenLayerID();
+        if (penSkinId >= 0) {
+            const penState = this._getPenState(target);
+            this.runtime.renderer.penClear(penSkinId);
+            this.runtime.requestRedraw();
+
+            // Sprite needs to be stamped to appear behind the pen's drawing
+            target.setCostume(target.getCostumeIndexByName(args.PICTURE));
+            this.runtime.renderer.penStamp(penSkinId, target.drawableID);
+            this.runtime.requestRedraw();
+            target.setCostume('costume1');
+
+            this.setPenSizeTo(1, target);
+            // Draw all sides of the grid and vertical dividers
+            this.runtime.renderer.penLine(penSkinId, penState.penAttributes, this._xCenter, this._yCenter, this._xCenter + this._gridWidth, this._yCenter);
+            for (let i = 0; i * this._interval <= this._gridWidth; i++) {
+                this.runtime.renderer.penLine(penSkinId, penState.penAttributes, this._xCenter + (i * this._interval), this._yCenter, this._xCenter + (i * this._interval), this._yCenter + this._gridHeight);
+            }
+            this.runtime.renderer.penLine(penSkinId, penState.penAttributes, this._xCenter, this._yCenter + this._gridHeight, this._xCenter + this._gridWidth, this._yCenter + this._gridHeight);
+
+            // Draw middle horizontal dividers
+            for (let j = 1; j * this._interval < this._gridHeight; j++) {
+                this.runtime.renderer.penLine(penSkinId, penState.penAttributes, this._xCenter, this._yCenter + (j * this._interval), this._xCenter + this._gridWidth, this._yCenter + (j * this._interval));
+            }
+
+            // Fill boxes with corresponding colors
+            for (let k = 0; k < this._gridValues.length; k++) {
+                const {x, y, count} = this._gridValues[k];
+                let xStart = this._xCenter + ((x - 1) * this._interval) + 1;
+                const yStart = this._yCenter + ((y - 1) * this._interval) + 1;
+                this.setPenColorToColor(this.checkColorState(count), target);
+
+                // Fill the current box without touching the borders
+                for (let i = 0; i < this._interval - 2; i++) {
+                    this.runtime.renderer.penLine(penSkinId, penState.penAttributes, xStart, yStart, xStart, yStart + this._interval - 2);
+                    xStart++;
+                }
+            }
+        }
+    }
+
     // HELPER METHODS
+
+    /**
+     * Checks the value and returns its corresponding severity color.
+     * @param {number} value - number of cases in a box of a heatmap
+     * @returns {string} hex color corresponding to the severity.
+     */
+    checkColorState (value) {
+        if (value >= 0 && value <= 20) {
+            return this._safeColor;
+        } else if (value > 20 && value <= 50) {
+            return this._mildColor;
+        } else if (value > 51 && value <= 100) {
+            return this._severeColor;
+        }
+        return this._dangerColor;
+    }
 
     /**
      * Move x steps.
@@ -965,12 +1133,12 @@ class Scratch3VizBlocks {
         this.processText(label, penSkinId, axisOption, target);
 
         // generate internal markers
-        if (axisOption === 'X'){
-            for (let i = 0; i * this._interval <= this._width; i++){
+        if (axisOption === 'X') {
+            for (let i = 0; i * this._interval <= this._chartWidth; i++) {
                 this.runtime.renderer.penLine(penSkinId, penState.penAttributes, this._xCenter + (i * this._interval), this._yCenter, this._xCenter + (i * this._interval), this._yCenter + 5);
             }
-        } else if (axisOption === 'Y'){
-            for (let j = 1; j * this._interval <= this._height; j++){
+        } else if (axisOption === 'Y') {
+            for (let j = 1; j * this._interval <= this._chartHeight; j++) {
                 this.runtime.renderer.penLine(penSkinId, penState.penAttributes, this._xCenter, this._yCenter + (j * this._interval), this._xCenter + 5, this._yCenter + (j * this._interval));
             }
         }


### PR DESCRIPTION
Fixes [visualization-literacy-playkit #11](https://github.com/VisualizationLiteracyPlayground/visualization-literacy-playkit/issues/11).

Implemented functionalities to draw a heatmap. Current limitations:
1. Target costume(s) must be first added by the user before loading the VizBlocks extension.
2. Costume(s) needs to be resized manually to fit the size of the current grid.

### Proposed Changes

![image](https://user-images.githubusercontent.com/25320782/77670801-a7095780-6fc1-11ea-9090-44d7a6bb6927.png)

Demo costume:
![world-map](https://user-images.githubusercontent.com/25320782/77838963-4d648100-71ab-11ea-8e61-55f227be183e.jpg)

